### PR TITLE
Fix brew detection

### DIFF
--- a/functions/php-version.fish
+++ b/functions/php-version.fish
@@ -64,7 +64,7 @@ function php-version --description 'function allowing one to switch between PHP 
   end
 
   # add default Homebrew directories if brew is installed
-  if test -n (command -v brew)
+  if available brew
     set _PHP_VERSIONS (find (brew --cellar) -maxdepth 1 -type d | grep -E 'php[0-9]*$')
   end
 
@@ -156,7 +156,7 @@ function php-version --description 'function allowing one to switch between PHP 
     end
 
     # bail-out if we were unable to find a PHP matching given version
-    if test -z "$_PHP_ROOT" 
+    if test -z "$_PHP_ROOT"
       echo "Sorry, but $PROGRAM_APPNAME was unable to find version '$argv[1]'." >&2
       return 1
     end


### PR DESCRIPTION
It seems like `php-version` was always assuming `brew` installed even when its not, resulting in output like this:

```
No command 'brew' found, did you mean:
 Command 'qbrew' from package 'qbrew' (universe)
 Command 'brec' from package 'bplay' (universe)
brew: command not found
in command substitution
        called on line 18 of file ~/.local/share/omf/pkg/php-version/functions/php-version.fish

in command substitution
        called on line 18 of file ~/.local/share/omf/pkg/php-version/functions/php-version.fish

in function “php-version”
        called on standard input

Sorry, but you do not seem to have any PHP versions installed.
See https://github.com/wilmoore/php-version#install for assistance.
```

The `available` command provided by Oh My Fish! is much more suitable for checking if a command is available anyway.
